### PR TITLE
add new preview-banner and future-posts

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -16,6 +16,7 @@ blog_intro: "In unserem Blog nehmen wir Sie mit auf eine spannende Reise quer du
 # _plugins directory
 permalink: blog-posts/:year-:month-:day/:title.html
 timezone: Europe/Berlin
+future: true
 
 #Pagination
 pagination:

--- a/_includes/preview-banner.html
+++ b/_includes/preview-banner.html
@@ -1,0 +1,18 @@
+{% if page.date > site.time %}
+<script type="text/javascript">
+    $(document).ready(function(){
+        $("#adesso-content").append("<div class='label label-warning' style='position:fixed; top:5em; width:5em; " +
+            "font-size:2em; line-height:1.7em;  color:white; background-color:#0275d8; font-weight:700; " +
+            "text-align:center; border-radius:.35em'>PREVIEW " +
+            "<div style='font-size: 0.5em'>Achtung! Der Artikel enthält ein Datum, dass in der Zukunft liegt!</div></div>")
+    });
+</script>
+{% else %}
+<script type="text/javascript">
+    $(document).ready(function(){
+        $("#adesso-content").append("<div class='label label-warning' style='position:fixed; top:5em; width:5em; " +
+            "font-size:2em; line-height:1.7em;  color:white; background-color:#0275d8; font-weight:700; " +
+            "text-align:center; border-radius:.35em'>PREVIEW</div>")
+    });
+</script>
+{% endif %}

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -2,6 +2,7 @@
 layout: default
 ---
 {% include display-content.html %}
+{% include preview-banner.html %}
 <div class="adesso-github-blog-wrapper">
 <div class="adesso-text-formate adesso-primary-orange">
 <div class="row p-t-2">


### PR DESCRIPTION
Future posts now can be displayed in the preview. 
Also the preview-snipped was removed from netlify, which was really unintuitive.

Fixes #46 