### PR TITLE
Fix missing teaser in detail view

### DIFF
--- a/_layouts/post-xml.xml
+++ b/_layouts/post-xml.xml
@@ -28,7 +28,7 @@
             {%- endif -%}
             ]]></field>
         <!--Picture-->
-        <!-- Not in use in the moment
+        <!-- Not in use at the moment
     {%- if page.images -%}
         {% for image in page.images%}
         <field name="pictureInOverview_stored_only"><![CDATA[assets/images/originals/{{image}}]]></field>
@@ -51,7 +51,7 @@
 <div class="row p-t-2">
 <div class="adesso-container">
 <div class="col-xl-8 adesso-center p-b-1 p-l-0 p-r-0">
-    {{ content | remove: page.excerpt | replace: '../assets','/assets' }}
+    {{ content | replace: '../assets','/assets' }}
 </div>
 </div>
 </div>


### PR DESCRIPTION
This should fix #54. 
The teaser is now included into the `content` section of the XML file. 