### PR TITLE
Hotfix: bundler installation in CI pipeline

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: ruby
 rvm:
 - 2.2.5
 before_install:
-  - gem install bundler --pre
+  - gem install bundler --pre #fails
 
 script: ./ci-build.sh
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: ruby
 rvm:
 - 2.2.5
 before_install:
-  - gem install bundler --pre #fails
+  - gem install bundler -v 1.17
 
 script: ./ci-build.sh
 

--- a/ci-build.sh
+++ b/ci-build.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
 set -e # halt script on error
 
-gem install bundler --pre
+gem install bundler -v 1.17
 bundle exec jekyll build


### PR DESCRIPTION
The bundler installation fails with the message:

```
$ gem install bundler --pre
Fetching: bundler-2.0.0.pre.1.gem (100%)
ERROR:  Error installing bundler:
	The last version of bundler (>= 0) to support your Ruby & RubyGems was 1.17.1. Try installing it with `gem install bundler -v 1.17.1`
	bundler requires Ruby version >= 2.3.0. The current ruby version is 2.2.0.
The command "gem install bundler --pre" failed and exited with 1 during .
```