### PR TITLE
Fix name of post category for the hazelcast post

### DIFF
--- a/_posts/2018-11-12-distributed-execution-mit-hazelcast.md
+++ b/_posts/2018-11-12-distributed-execution-mit-hazelcast.md
@@ -2,6 +2,7 @@
 layout: [post, post-xml]
 title: "Distributed Execution mit Hazelcast"
 date: 2018-11-12 14:00:00
+modified_date: 2018-12-12
 author: karnik
 categories: [Architektur]
 tags: [Microservices,Mainframe,Migration,Hazelcast]

--- a/_posts/2018-11-12-distributed-execution-mit-hazelcast.md
+++ b/_posts/2018-11-12-distributed-execution-mit-hazelcast.md
@@ -3,7 +3,7 @@ layout: [post, post-xml]
 title: "Distributed Execution mit Hazelcast"
 date: 2018-11-12 14:00:00
 author: karnik
-categories: [Architekturen]
+categories: [Architektur]
 tags: [Microservices,Mainframe,Migration,Hazelcast]
 ---
 


### PR DESCRIPTION
Das sollte dafür sorgen, dass die Kategorie im Devblog korrekt angezeigt wird.