### PR TITLE
Fixing blog post design

### DIFF
--- a/_includes/display-content.html
+++ b/_includes/display-content.html
@@ -51,11 +51,7 @@
                 <div class="adesso-text-formate adesso-secondary-orange">
                         <div class="row p-t-2 p-l-0 p-r-0">
                                 <div class="blog-text col-md-12 col-xl-8 adesso-center">
-                                        {% if page.layout == 'post' %}
-                                        <p>{{ page.excerpt }}<p>
-                                                        {% else %}
-                                                        {{ site.blog_intro }}
-                                                        {% endif %}
+                                        <p>{{ content }}<p>
                                 </div>
                         </div>
 

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -4,4 +4,3 @@ layout: default
 {% include blog-header.html %}
 {% include preview-banner.html %}
 {% include display-content.html %}
-{{ content | remove: page.excerpt }}


### PR DESCRIPTION
Basierend auf dem Problem aus #93 mit dem neuen Blog-Design habe ich den aktuellen Stand nochmal überarbeitet. 

Meines Erachtens nach entsteht das Problem in der Datei 'display-content.html' im folgenden Abschnitt:
`                                        {% if page.layout == 'post' %}
                                        <p>{{ page.excerpt }}<p>
                                                        {% else %}
                                                        {{ site.blog_intro }}
                                                        {% endif %}`

Es scheint, dass ein lokales Ausführen von Jekyll das 'page.layout' als 'post' erkennt, allerdings das serverseitige Ausführen in diesem Bereich ein anderes Verhalten hat. Dadurch wird nur der else-Pfad ausgeführt und nur der Teaser des Blog-Beitrags dargestellt.
Darauffolgend wird die Fußzeile mit den Autoreninformationen ausgegeben. Der restliche Text des Beitrages wird in der Datei 'post.html' mittels `{{ content | remove: page.excerpt }}` eingefügt.

Wofür die If-Else-Verzweigung im ursprünglichen Design zuständig war ist mir nicht bekannt, allerdings kann im neuen Design darauf verzichtet werden und der Inhalt des Blog-Beitrages direkt in der Datei 'display-content.html' mittels `<p>{{ content }}<p>` eingefügt werden.

Im lokalen Betrieb von Jekyll habe ich ein identisches Ergebnis erhalten. @silasmahler oder @florianluediger sollte das Verhalten ebenfalls nochmal serverseitig überprüfen, da fehlt mir der Zugriff drauf.