### PR TITLE
Identify bottlenecks in your Spring Tests with JUnit Insights

### DIFF
--- a/_posts/2019-08-02-identify-bottlenecks-in-your-spring-tests-with-junit-insights.md
+++ b/_posts/2019-08-02-identify-bottlenecks-in-your-spring-tests-with-junit-insights.md
@@ -1,0 +1,26 @@
+---
+layout: [post, post-xml]              # Pflichtfeld. Nicht ändern!
+title:  "Identify bottlenecks in your Spring Tests with JUnit Insights"         # Pflichtfeld. Bitte einen Titel für den Blog Post angeben.
+date:   2019-08-02 10:25              # Pflichtfeld. Format "YYYY-MM-DD HH:MM". Muss für Veröffentlichung in der Vergangenheit liegen. (Für Preview egal)
+author: florianluediger               # Pflichtfeld. Es muss in der "authors.yml" einen Eintrag mit diesem Namen geben.
+categories: [Java]                    # Pflichtfeld. Maximal eine der angegebenen Kategorien verwenden.
+tags: [Spring, JUnit]                 # Bitte auf Großschreibung achten.
+---
+
+Teaser
+
+# Why do my Spring tests take so long?
+
+# Situations that require a fresh Application Context
+
+## `@DirtiesContext` annotation
+
+## Nested test classes
+
+## Custom properties for Spring Boot Test
+
+## Different profiles
+
+## Web MVC Test for one Controller
+
+# How to recognize these situations

--- a/_posts/2019-08-02-identify-bottlenecks-in-your-spring-tests-with-junit-insights.md
+++ b/_posts/2019-08-02-identify-bottlenecks-in-your-spring-tests-with-junit-insights.md
@@ -27,6 +27,8 @@ On the other hand this requires many different Application Contexts that take a 
 
 The following list represents an incomplete list of some examples for situations which lead to the creation of a new Application Context during the execution of your Unit Tests.
 
+A complete project containing all these scenarios with the necessary surrounding code [can be found on GitHub](https://github.com/florianluediger/ContextRefreshesInSpringTest).
+
 ## Explicit invalidation of a context
 
 First of all, you can of course explicitly invalidate an Application Context so a new one has to be created for the following test cases.
@@ -60,6 +62,8 @@ class FruitManagerTest {
     }
 }
 ```
+
+[Link to JUnit Insights Report](https://florianluediger.github.io/ContextRefreshesInSpringTest/JUnit%20Insights%20reports/JUnit%20Insights%20Report%20-%20Explicit%20invalidation%20of%20a%20context.html)
 
 ## Individual test profiles
 
@@ -101,6 +105,8 @@ class FruitManagerDevTest {
 }
 ```
 
+[Link to JUnit Insights Report](https://florianluediger.github.io/ContextRefreshesInSpringTest/JUnit%20Insights%20reports/JUnit%20Insights%20Report%20-%20Individual%20test%20profiles.html)
+
 ## Custom properties
 
 When testing your application, sometimes it makes sense to overwrite properties previously defined in the `application.properties` file.
@@ -121,6 +127,8 @@ class FruitManagerMelonTest {
     }
 }
 ```
+
+[Link to JUnit Insights Report](https://florianluediger.github.io/ContextRefreshesInSpringTest/JUnit%20Insights%20reports/JUnit%20Insights%20Report%20-%20Custom%20properties.html)
 
 ## Web MVC Test for single Controller
 
@@ -152,4 +160,26 @@ class VegetableControllerTest {
 }
 ```
 
+[Link to JUnit Insights Report](https://florianluediger.github.io/ContextRefreshesInSpringTest/JUnit%20Insights%20reports/JUnit%20Insights%20Report%20-%20Web%20MVC%20Test%20for%20single%20Controller.html)
+
 # How to recognize these situations
+
+Even if you are aware of the fact that situations like these require a refresh of the Application Context, finding them in a large collection of software tests can be very hard.
+The reason for this is that the text runner typically does not give you much information about when or where a new Application Context is started.
+The only metric that you can often see is the time that each test class took to finish.
+This alone often times just leads to confusion about why some test classes take more time to finish than others.
+
+To solve this problem you can use the JUnit 5 extension [JUnit Insights](https://github.com/adessoag/junit-insights).
+This plugin measures the time for setup, execution and teardown for each test method in each test class.
+It also counts how often Spring Contexts were created throughout the test execution and how long this takes each time.
+With this data, it creates a nice looking report that visualizes the information.
+You can see a snippet of a finished report in the screenshot below.
+
+![JUnit Insights report example](https://github.com/adessoAG/junit-insights/raw/master/images/screen1.png)
+
+In this report, you can clearly see where Spring Contexts are created and how long that takes.
+Based on this information, you can dive into your code, identify the reasons for the Context refreshes and possibly optimize your test execution by eliminating them.
+This way your test execution time decreases, your continuous integration pipelines will give you faster feedback about software errors and your developers will get happier.
+
+To make using this extension as easy as possible, it is available via a [JCenter repository](https://bintray.com/adesso/junit-insights/junit-insights) and it can be configured inside your Gradle or Maven configuration files.
+For more information on how to use the plugin and how the inner workings function, check out the [GitHub repository](https://github.com/adessoag/junit-insights).

--- a/_posts/2019-08-02-identify-bottlenecks-in-your-spring-tests-with-junit-insights.md
+++ b/_posts/2019-08-02-identify-bottlenecks-in-your-spring-tests-with-junit-insights.md
@@ -4,24 +4,24 @@ title:  "Identify bottlenecks in your Spring Tests with JUnit Insights"         
 date:   2019-08-02 10:25              # Pflichtfeld. Format "YYYY-MM-DD HH:MM". Muss für Veröffentlichung in der Vergangenheit liegen. (Für Preview egal)
 author: florianluediger               # Pflichtfeld. Es muss in der "authors.yml" einen Eintrag mit diesem Namen geben.
 categories: [Java]                    # Pflichtfeld. Maximal eine der angegebenen Kategorien verwenden.
-tags: [Spring, JUnit]                 # Bitte auf Großschreibung achten.
+tags: [Spring, JUnit, Testing]        # Bitte auf Großschreibung achten.
 ---
 
 When developing a large software project, a low execution time of Unit Tests is crucial to guarantee a fast and efficient progression of the project.
-This is especially true when utilizing continuous integration to automatically check code quality and correctness.
-JUnit Insights helps you to identify the reasons behind long execution times of some of your software tests so you can optimize them easily.
+This is especially true when utilizing continuous integration to automatically check your code quality and correctness.
+[JUnit Insights](https://github.com/adessoag/junit-insights) helps you to identify the reasons behind long execution times of some of your software tests so you can optimize them easily.
 
 # Why do my Spring tests take so long?
 
-Whenever you are writing Unit Tests that require features provided by the annotations `@SpringBootTest`, `@DataJPATest`, `@WebMVCTest` or similar, a Spring Application Context will be created to provide the environment these tests need to run.
+Whenever you are writing Unit Tests that require features provided by the annotations [`@SpringBootTest`](https://docs.spring.io/spring-boot/docs/current/api/org/springframework/boot/test/context/SpringBootTest.html), [`@DataJPATest`](https://docs.spring.io/spring-boot/docs/current/api/org/springframework/boot/test/autoconfigure/orm/jpa/DataJpaTest.html), [`@WebMVCTest`](https://docs.spring.io/spring-boot/docs/current/api/org/springframework/boot/test/autoconfigure/web/servlet/WebMvcTest.html) or similar, a [Spring Application Context](https://docs.spring.io/spring-framework/docs/current/javadoc-api/org/springframework/context/ApplicationContext.html) will be created to provide the environment these tests need to run.
 
-This Application Context bundles the complete Bean Configuration of the application which forms the foundation for the Dependency Injection mechanism.
-The Bean Configuration contains the information about dependencies between all components of the application.
+This Application Context bundles the complete Bean Configuration of the application, which forms the foundation for the Dependency Injection mechanism.
+The Bean Configuration contains all information about dependencies between all components of your application.
 Usually this configuration is defined when starting the application and it remains unchanged throughout the runtime.
 
-However, when writing autonomous Unit Tests for your application there are situations where you want to create multiple independent Application Contexts for different test cases.
-On one hand this can lead to very simple and autonomous test cases that are robust against side effects caused by other test cases altering the Application Context.
-On the other hand this requires many different Application Contexts that take a long time to start up which slows down your test execution significantly.
+However, when writing autonomous Unit Tests for your application, there are situations where you want to create multiple independent Application Contexts for different test cases.
+On one hand, this can lead to very simple and autonomous test cases that are robust against side effects caused by other test cases altering the Application Context.
+On the other hand, this requires many different Application Contexts that take a long time to start up which slows down your test execution significantly.
 
 # Situations that require a fresh Application Context
 
@@ -32,10 +32,10 @@ A complete project containing all these scenarios with the necessary surrounding
 ## Explicit invalidation of a context
 
 First of all, you can of course explicitly invalidate an Application Context so a new one has to be created for the following test cases.
-This makes sense when you change the Application Context within a test method which could influence the outcome of other test cases.
-This would mean that the unit tests are not independent anymore which is a dangerous anti pattern.
+This makes sense when you change the Application Context within a test method, which could influence the outcome of other test cases.
+This would mean that the unit tests are not independent anymore, which is a dangerous anti pattern.
 
-In the following example, the test methods modify the state of a singleton bean so the annotation `@DirtiesContext` is needed to force the test runner to create a new Application Context afterwards.
+In the following example, the test methods modify the state of a singleton Bean so the annotation [`@DirtiesContext`](https://docs.spring.io/spring/docs/current/javadoc-api/org/springframework/test/annotation/DirtiesContext.html) is needed to force the test runner to create a new Application Context afterwards.
 
 ```java
 @SpringBootTest
@@ -68,8 +68,8 @@ class FruitManagerTest {
 ## Individual test profiles
 
 You can define different profiles for the execution of your Spring Boot application.
-For example these profiles can define which implementation of a Bean is used in different contexts.
-In our example, you can define a different instance of the `FruitManager` Bean for the `dev` environment by labeling the Bean class with the `@Profile("dev")` annotation and the test class with the `@ActiveProfiles("dev")` annotation.
+For example, these profiles can define which implementation of a Bean is used in different contexts.
+In our example, you can define a different instance of the `FruitManager` Bean for the `dev` environment by labeling the Bean class with the [`@Profile("dev")`](https://docs.spring.io/spring-framework/docs/current/javadoc-api/org/springframework/context/annotation/Profile.html) annotation and the test class with the [`@ActiveProfiles("dev")`](https://docs.spring.io/spring/docs/current/javadoc-api/org/springframework/test/context/ActiveProfiles.html) annotation.
 
 ```java
 @Component
@@ -111,7 +111,7 @@ class FruitManagerDevTest {
 
 When testing your application, sometimes it makes sense to overwrite properties previously defined in the `application.properties` file.
 The configured properties are part of the Application Context which means that changing these requires a refresh.
-You can overwrite properties inside the parameters of the `@SpringBootTest` annotation as demonstrated in this example.
+You can overwrite properties inside the parameters of the [`@SpringBootTest`](https://docs.spring.io/spring-boot/docs/current/api/org/springframework/boot/test/context/SpringBootTest.html) annotation as demonstrated in this example.
 
 ```java
 @SpringBootTest(properties = {"fruit.name=Melon"})
@@ -134,9 +134,9 @@ class FruitManagerMelonTest {
 
 To guarantee that your unit tests are as independent from each other as possible, you should construct your web endpoint tests in a way that isolates functional groups.
 In our example this means that the test class for validating the `VegetableController` class should have nothing to do with other controllers like the `FruitController`.
-To achieve this we have to specify the tested controller as a parameter of the `@WebMVCTest` annotation.
+To achieve this, we have to specify the tested controller as a parameter of the [`@WebMVCTest`](https://docs.spring.io/spring-boot/docs/current/api/org/springframework/boot/test/autoconfigure/web/servlet/WebMvcTest.html) annotation.
 If we had not done this in this example, Spring would complain about a missing instance of the `FruitManager` Bean.
-Although this Bean is not even used in this test class, the test runner tries to create the complete Application Context which fails because it can't find any real or mock instance of the `FruitManager` Bean.
+Although this Bean is not even used in this test class, the test runner tries to create the whole Application Context which fails because it can't find any actual or mocked instance of the `FruitManager` Bean.
 
 ```java
 @WebMvcTest(VegetableController.class)
@@ -167,7 +167,7 @@ class VegetableControllerTest {
 Even if you are aware of the fact that situations like these require a refresh of the Application Context, finding them in a large collection of software tests can be very hard.
 The reason for this is that the text runner typically does not give you much information about when or where a new Application Context is started.
 The only metric that you can often see is the time that each test class took to finish.
-This alone often times just leads to confusion about why some test classes take more time to finish than others.
+This alone oftentimes just leads to confusion about why some test classes take more time to finish than others.
 
 To solve this problem you can use the JUnit 5 extension [JUnit Insights](https://github.com/adessoag/junit-insights).
 This plugin measures the time for setup, execution and teardown for each test method in each test class.

--- a/_posts/2019-08-02-identify-bottlenecks-in-your-spring-tests-with-junit-insights.md
+++ b/_posts/2019-08-02-identify-bottlenecks-in-your-spring-tests-with-junit-insights.md
@@ -7,39 +7,38 @@ categories: [Java]                    # Pflichtfeld. Maximal eine der angegebene
 tags: [Spring, JUnit, Testing]        # Bitte auf Großschreibung achten.
 ---
 
-When developing a large software project, a low execution time of Unit Tests is crucial to guarantee a fast and efficient progression of the project.
-This is especially true when utilizing continuous integration to automatically check your code quality and correctness.
+When developing a large software project, a low execution time of unit tests is crucial to guarantee a fast and efficient progression of the project.
+This is especially true when using continuous integration to automatically check your code quality and correctness.
 [JUnit Insights](https://github.com/adessoag/junit-insights) helps you to identify the reasons behind long execution times of some of your software tests so you can optimize them easily.
 
 # Why do my Spring tests take so long?
 
-Whenever you are writing Unit Tests that require features provided by the annotations [`@SpringBootTest`](https://docs.spring.io/spring-boot/docs/current/api/org/springframework/boot/test/context/SpringBootTest.html), [`@DataJPATest`](https://docs.spring.io/spring-boot/docs/current/api/org/springframework/boot/test/autoconfigure/orm/jpa/DataJpaTest.html), [`@WebMVCTest`](https://docs.spring.io/spring-boot/docs/current/api/org/springframework/boot/test/autoconfigure/web/servlet/WebMvcTest.html) or similar, a [Spring Application Context](https://docs.spring.io/spring-framework/docs/current/javadoc-api/org/springframework/context/ApplicationContext.html) will be created to provide the environment these tests need to run.
+Whenever you are writing unit tests that require features provided by the annotations [`@SpringBootTest`](https://docs.spring.io/spring-boot/docs/current/api/org/springframework/boot/test/context/SpringBootTest.html), [`@DataJpaTest`](https://docs.spring.io/spring-boot/docs/current/api/org/springframework/boot/test/autoconfigure/orm/jpa/DataJpaTest.html), [`@WebMvcTest`](https://docs.spring.io/spring-boot/docs/current/api/org/springframework/boot/test/autoconfigure/web/servlet/WebMvcTest.html) or similar, a [Spring ApplicationContext](https://docs.spring.io/spring-framework/docs/current/javadoc-api/org/springframework/context/ApplicationContext.html) will be created to provide the environment these tests need to run.
 
-This Application Context bundles the complete Bean Configuration of the application, which forms the foundation for the Dependency Injection mechanism.
-The Bean Configuration contains all information about dependencies between all components of your application.
+This ApplicationContext bundles the complete bean configuration of the application, which forms the foundation for the dependency injection mechanism.
+The bean configuration contains all information about dependencies between all components of your application.
 Usually this configuration is defined when starting the application and it remains unchanged throughout the runtime.
 
-However, when writing autonomous Unit Tests for your application, there are situations where you want to create multiple independent Application Contexts for different test cases.
-On one hand, this can lead to very simple and autonomous test cases that are robust against side effects caused by other test cases altering the Application Context.
-On the other hand, this requires many different Application Contexts that take a long time to start up which slows down your test execution significantly.
+However, when writing isolated unit tests for your application, there are situations where you want to create multiple independent ApplicationContext for different test cases.
+On one hand, this can lead to very simple test cases that are invulnerable to side effects caused by other test cases altering the ApplicationContext.
+On the other hand, this requires many different ApplicationContext that take a long time to start up, slowing down your test execution significantly.
 
-# Situations that require a fresh Application Context
+# Situations that require a fresh ApplicationContext
 
-The following list represents an incomplete list of some examples for situations which lead to the creation of a new Application Context during the execution of your Unit Tests.
+The following is an incomplete list of situations which lead to the creation of a new ApplicationContext during the execution of your unit tests.
 
-A complete project containing all these scenarios with the necessary surrounding code [can be found on GitHub](https://github.com/florianluediger/ContextRefreshesInSpringTest).
+You can find a complete project containing all these scenarios with the necessary surrounding code [on GitHub](https://github.com/florianluediger/ContextRefreshesInSpringTest).
 
 ## Explicit invalidation of a context
 
-First of all, you can of course explicitly invalidate an Application Context so a new one has to be created for the following test cases.
-This makes sense when you change the Application Context within a test method, which could influence the outcome of other test cases.
+First of all, you can of course explicitly invalidate an ApplicationContext so a new one has to be created for the following test cases.
+This makes sense when you modify the ApplicationContext within a test method, which could influence the outcome of other test cases.
 This would mean that the unit tests are not independent anymore, which is a dangerous anti pattern.
 
-In the following example, the test methods modify the state of a singleton Bean so the annotation [`@DirtiesContext`](https://docs.spring.io/spring/docs/current/javadoc-api/org/springframework/test/annotation/DirtiesContext.html) is needed to force the test runner to create a new Application Context afterwards.
+In the following example, the test methods modify the state of a singleton bean so the annotation [`@DirtiesContext`](https://docs.spring.io/spring/docs/current/javadoc-api/org/springframework/test/annotation/DirtiesContext.html) is needed to force the test runner to create a new ApplicationContext afterwards:
 
 ```java
 @SpringBootTest
-@ExtendWith(SpringExtension.class)
 class FruitManagerTest {
 
     @Autowired
@@ -69,7 +68,7 @@ class FruitManagerTest {
 
 You can define different profiles for the execution of your Spring Boot application.
 For example, these profiles can define which implementation of a Bean is used in different contexts.
-In our example, you can define a different instance of the `FruitManager` Bean for the `dev` environment by labeling the Bean class with the [`@Profile("dev")`](https://docs.spring.io/spring-framework/docs/current/javadoc-api/org/springframework/context/annotation/Profile.html) annotation and the test class with the [`@ActiveProfiles("dev")`](https://docs.spring.io/spring/docs/current/javadoc-api/org/springframework/test/context/ActiveProfiles.html) annotation.
+In our example, you can define a different instance of the `FruitManager` Bean for the `dev` environment by labeling the Bean class with the [`@Profile("dev")`](https://docs.spring.io/spring-framework/docs/current/javadoc-api/org/springframework/context/annotation/Profile.html) annotation and the test class with the [`@ActiveProfiles("dev")`](https://docs.spring.io/spring/docs/current/javadoc-api/org/springframework/test/context/ActiveProfiles.html) annotation:
 
 ```java
 @Component
@@ -91,7 +90,6 @@ public class FruitManagerDev implements FruitManager {
 
 ```java
 @SpringBootTest
-@ExtendWith(SpringExtension.class)
 @ActiveProfiles("dev")
 class FruitManagerDevTest {
 
@@ -107,15 +105,16 @@ class FruitManagerDevTest {
 
 [Link to JUnit Insights Report](https://florianluediger.github.io/ContextRefreshesInSpringTest/JUnit%20Insights%20reports/JUnit%20Insights%20Report%20-%20Individual%20test%20profiles.html)
 
+If this test is run together with the test from the last section, a new ApplicationContext will be created for both tests.
+
 ## Custom properties
 
 When testing your application, sometimes it makes sense to overwrite properties previously defined in the `application.properties` file.
-The configured properties are part of the Application Context which means that changing these requires a refresh.
+The configured properties are part of the ApplicationContext which means that changing them requires a refresh.
 You can overwrite properties inside the parameters of the [`@SpringBootTest`](https://docs.spring.io/spring-boot/docs/current/api/org/springframework/boot/test/context/SpringBootTest.html) annotation as demonstrated in this example.
 
 ```java
 @SpringBootTest(properties = {"fruit.name=Melon"})
-@ExtendWith(SpringExtension.class)
 class FruitManagerMelonTest {
 
     @Autowired
@@ -134,13 +133,12 @@ class FruitManagerMelonTest {
 
 To guarantee that your unit tests are as independent from each other as possible, you should construct your web endpoint tests in a way that isolates functional groups.
 In our example this means that the test class for validating the `VegetableController` class should have nothing to do with other controllers like the `FruitController`.
-To achieve this, we have to specify the tested controller as a parameter of the [`@WebMVCTest`](https://docs.spring.io/spring-boot/docs/current/api/org/springframework/boot/test/autoconfigure/web/servlet/WebMvcTest.html) annotation.
-If we had not done this in this example, Spring would complain about a missing instance of the `FruitManager` Bean.
-Although this Bean is not even used in this test class, the test runner tries to create the whole Application Context which fails because it can't find any actual or mocked instance of the `FruitManager` Bean.
+To achieve this, we have to specify the tested controller as a parameter of the [`@WebMvcTest`](https://docs.spring.io/spring-boot/docs/current/api/org/springframework/boot/test/autoconfigure/web/servlet/WebMvcTest.html) annotation.
+If we had not done this in this example, Spring would complain about a missing instance of the `FruitManager` bean.
+Although this bean is not even used in this test class, the test runner tries to create the whole ApplicationContext which fails because it can't find any actual or mocked instance of the `FruitManager` bean.
 
 ```java
 @WebMvcTest(VegetableController.class)
-@ExtendWith(SpringExtension.class)
 class VegetableControllerTest {
 
     @Autowired
@@ -164,10 +162,10 @@ class VegetableControllerTest {
 
 # How to recognize these situations
 
-Even if you are aware of the fact that situations like these require a refresh of the Application Context, finding them in a large collection of software tests can be very hard.
-The reason for this is that the text runner typically does not give you much information about when or where a new Application Context is started.
+Even if you are aware of the fact that situations like these require a refresh of the ApplicationContext, finding them in a large collection of software tests can be very hard.
+The reason for this is that the text runner typically does not give you much information about when or where a new ApplicationContext is started.
 The only metric that you can often see is the time that each test class took to finish.
-This alone oftentimes just leads to confusion about why some test classes take more time to finish than others.
+This alone often just leads to confusion about why some test classes take more time to finish than others.
 
 To solve this problem you can use the JUnit 5 extension [JUnit Insights](https://github.com/adessoag/junit-insights).
 This plugin measures the time for setup, execution and teardown for each test method in each test class.
@@ -177,7 +175,7 @@ You can see a snippet of a finished report in the screenshot below.
 
 ![JUnit Insights report example](https://github.com/adessoAG/junit-insights/raw/master/images/screen1.png)
 
-In this report, you can clearly see where Spring Contexts are created and how long that takes.
+In this report, you can clearly see where Spring ApplicationContexts are created and how long that takes.
 Based on this information, you can dive into your code, identify the reasons for the Context refreshes and possibly optimize your test execution by eliminating them.
 This way your test execution time decreases, your continuous integration pipelines will give you faster feedback about software errors and your developers will get happier.
 

--- a/_posts/2019-08-02-identify-bottlenecks-in-your-spring-tests-with-junit-insights.md
+++ b/_posts/2019-08-02-identify-bottlenecks-in-your-spring-tests-with-junit-insights.md
@@ -7,11 +7,25 @@ categories: [Java]                    # Pflichtfeld. Maximal eine der angegebene
 tags: [Spring, JUnit]                 # Bitte auf Großschreibung achten.
 ---
 
-Teaser
+When developing a large software project, a low execution time of Unit Tests is crucial to guarantee a fast and efficient progression of the project.
+This is especially true when utilizing continuous integration to automatically check code quality and correctness.
+JUnit Insights helps you to identify the reasons behind long execution times of some of your software tests so you can optimize them easily.
 
 # Why do my Spring tests take so long?
 
+Whenever you are writing Unit Tests that require features provided by the annotations `@SpringBootTest`, `@DataJPATest`, `@WebMVCTest` or similar, a Spring Application Context will be created to provide the environment these tests need to run.
+
+This Application Context bundles the complete Bean Configuration of the application which forms the foundation for the Dependency Injection mechanism.
+The Bean Configuration contains the information about dependencies between all components of the application.
+Usually this configuration is defined when starting the application and it remains unchanged throughout the runtime.
+
+However, when writing autonomous Unit Tests for your application there are situations where you want to create multiple independent Application Contexts for different test cases.
+On one hand this can lead to very simple and autonomous test cases that are robust against side effects caused by other test cases altering the Application Context.
+On the other hand this requires many different Application Contexts that take a long time to start up which slows down your test execution significantly.
+
 # Situations that require a fresh Application Context
+
+The following list represents an incomplete list of some examples for situations which lead to the creation of a new Application Context during the execution of your Unit Tests.
 
 ## `@DirtiesContext` annotation
 

--- a/_posts/2019-08-20-identify-bottlenecks-in-your-spring-tests-with-junit-insights.md
+++ b/_posts/2019-08-20-identify-bottlenecks-in-your-spring-tests-with-junit-insights.md
@@ -1,7 +1,7 @@
 ---
 layout: [post, post-xml]              # Pflichtfeld. Nicht ändern!
-title:  "Identify bottlenecks in your Spring Tests with JUnit Insights"         # Pflichtfeld. Bitte einen Titel für den Blog Post angeben.
-date:   2019-08-02 10:25              # Pflichtfeld. Format "YYYY-MM-DD HH:MM". Muss für Veröffentlichung in der Vergangenheit liegen. (Für Preview egal)
+title:  "Identify Bottlenecks in your Spring Tests with JUnit Insights"         # Pflichtfeld. Bitte einen Titel für den Blog Post angeben.
+date:   2019-08-20 09:00             # Pflichtfeld. Format "YYYY-MM-DD HH:MM". Muss für Veröffentlichung in der Vergangenheit liegen. (Für Preview egal)
 author: florianluediger               # Pflichtfeld. Es muss in der "authors.yml" einen Eintrag mit diesem Namen geben.
 categories: [Java]                    # Pflichtfeld. Maximal eine der angegebenen Kategorien verwenden.
 tags: [Spring, JUnit, Testing]        # Bitte auf Großschreibung achten.


### PR DESCRIPTION
Wenn du einen Pull-Request stellst, teile uns bitte deine Änderungen mit, indem du die unten angegebene Publish-Checkliste nutzt. 

# Publish Checkliste

- **Meta** (abzuhaken durch den Autor)
  - [x] [Artikeldatei am richtigen Ort abgelegt](https://github.com/adessoAG/devblog/blob/master/examples/2017-08-10-blog-post-guide.md#dateiname-und-ablageort)
  - [x] [Autoreninfo gepflegt](https://github.com/adessoAG/devblog/blob/master/examples/2017-08-10-blog-post-guide.md#autoren-informationen)
  - [x] [Metadaten gepflegt:](https://github.com/adessoAG/devblog/blob/master/examples/2017-08-10-blog-post-guide.md#metadaten)
    - [x] "title" vergeben
    - [x] "author" angegeben
    - [x] "categories" enthält maximal eine der Hauptkategorien (Java, Microsoft, Methodik, Architekturen, Softwareentwicklung, Business & People)
    - [x] "tags" enthält (beliebige) passende Tags
- **Text** (abzuhaken durch den Autor)
  - [x] [Teaser entspricht den Vorgaben](https://github.com/adessoAG/devblog/blob/master/examples/2017-08-10-blog-post-guide.md#einleitung--teaser)
  - [x] Rechtschreibung korrigiert
  - [x] [Bilder sind korrekt in den Artikel eingebunden](https://github.com/adessoAG/devblog/blob/master/examples/2017-08-10-blog-post-guide.md#bilder)
  - [x] [Überschriften entsprechen den Vorgaben](https://github.com/adessoAG/devblog/blob/master/examples/2017-08-10-blog-post-guide.md#%C3%9Cberschriften)
  - [x] Code-Snippets wurden mit [Syntax Highlighting](https://github.com/adessoAG/devblog/blob/master/examples/2017-08-10-blog-post-guide.md#syntax-highlighting) versehen
  - [x] Der Artikel wurde in der [Vorschau](https://github.com/adessoAG/devblog/blob/master/examples/2017-08-10-blog-post-guide.md#online-preview) geprüft 
- **Review** (abzuhaken durch den Reviewer)
  - [ ] Rechtschreibung korrigiert
  - [ ] Der Artikel wurde in der [Vorschau](https://github.com/adessoAG/devblog/blob/master/examples/2017-08-10-blog-post-guide.md#online-preview) geprüft 
  - [ ] CCO wurde über neuen Artikel informiert
  - [ ] Date-Angaben 
    - [ ] stimmen im Header und im Dateinamen überein
    - [ ] stehen auf dem heutigen Tag (aber in der Vergangenheit)


