### PR TITLE
add blogpost checker

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -10,6 +10,7 @@ Wenn du einen Pull-Request stellst, teile uns bitte deine Änderungen mit, indem
     - [ ] "author" angegeben
     - [ ] "categories" enthält maximal eine der Hauptkategorien (Methodik, Architekturen, Softwareentwicklung, Branchen, Inside adesso)
     - [ ] "tags" enthält (beliebige) passende Tags
+  - [ ] Der blogpost-checker hat die Richtigkeit der Metadaten bestätigt (siehe CI Check)
 - **Text** (abzuhaken durch den Autor)
   - [ ] [Teaser entspricht den Vorgaben](https://github.com/adessoAG/devblog/blob/master/examples/2017-08-10-blog-post-guide.md#einleitung--teaser)
   - [ ] Rechtschreibung korrigiert

--- a/.github/workflows/validate-blogpost.yml
+++ b/.github/workflows/validate-blogpost.yml
@@ -1,0 +1,23 @@
+#Run blogpost-checker in a Docker container to validate the new blogpost
+name: validate-blogpost
+
+on:
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  pull-and-run-blogpost-checker-image:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@master
+
+      - name: Inject env
+        uses: rlespinasse/github-slug-action@v3.x
+
+      - name: Pull Docker image
+        run: docker pull jekyll2cms/blogpost-checker:1.0.0
+
+      - name: Run Docker image
+        run: docker run --env REPOSITORY_REMOTE_URL='https://github.com/${{ env.GITHUB_REPOSITORY_OWNER_PART }}/${{ env.GITHUB_REPOSITORY_NAME_PART }}' --env REPOSITORY_BRANCH_NAME='${{ env.GITHUB_HEAD_REF_SLUG }}' jekyll2cms/blogpost-checker:1.0.0


### PR DESCRIPTION
Add [blogpost-checker](https://github.com/adessoAG/blogpost-checker) as merge gate.

See it in action: https://github.com/jo2/devblog/pull/1.


Once this is merged, we can add a branch protection on master which requires a successful run of `pull-and-run-blogpost-checker-image`.